### PR TITLE
Fixed add-remove-owner test using updated data test ids

### DIFF
--- a/utils/selectors/settings.js
+++ b/utils/selectors/settings.js
@@ -7,10 +7,14 @@ export const settingsPage = {
   add_owner_review_btn: { selector: "[data-testid='add-owner-threshold-next-btn']", type: 'css' },
   add_owner_submit_btn: { selector: "[data-testid='add-owner-submit-btn']", type: 'css' },
   add_owner_submit_btn_disabled: { selector: "[data-testid='add-owner-submit-btn'][disabled]", type: 'css' },
+  add_owner_name_review: { selector: "[data-testid='add-owner-review'] div div div p", type: 'css' },
+  add_owner_address_review: { selector: "[data-testid='add-owner-review'] div div div div p", type: 'css' },
   remove_owner_trashcan_icon: { selector: "[data-testid='remove-owner-btn']", type: 'css' },
   remove_owner_next_btn: { selector: "[data-testid='remove-owner-next-btn']", type: 'css' },
   remove_owner_review_btn: { selector: "[data-testid='remove-owner-threshold-next-btn']", type: 'css' },
   remove_owner_submit_btn: { selector: "[data-testid='remove-owner-review-btn']", type: 'css' },
+  remove_owner_name_review: { selector: "[data-testid='remove-owner-review'] div div div p", type: 'css' },
+  remove_owner_address_review: { selector: "[data-testid='remove-owner-review'] div div div div p", type: 'css' },
 }
 
 export const settingsTabs = {


### PR DESCRIPTION
## What it solves

Fixes #8 

## How this PR fixes it

Make the test usable for any env variables

## How to test it

Use https://github.com/gnosis/safe-react/pull/2451 to run this test
Remember to use a safe with 2 owners
