### PR TITLE
Send run id on github action

### DIFF
--- a/.github/workflows/e2e-run-on-pr.yml
+++ b/.github/workflows/e2e-run-on-pr.yml
@@ -27,4 +27,4 @@ jobs:
         token: ${{ secrets.E2E_RUN_HOOK_ACCESS_TOKEN }}
         repository: gnosis/safe-react
         event-type: comment-pr-on-success
-        client-payload: '{"pr_number": "${{ github.event.client_payload.pr_number }}", "status": "${{ steps.test-code.outcome }}"}'
+        client-payload: '{"pr_number": "${{ github.event.client_payload.pr_number }}", "status": "${{ steps.test-code.outcome }}", "run_number": "${{ github.run_id }}"}'


### PR DESCRIPTION
Closes #37 

We send the run id on the event payload so the safe-react repo can recieve it.