### PR TITLE
Fix Load Safe test

### DIFF
--- a/src/load_safe.test.js
+++ b/src/load_safe.test.js
@@ -32,7 +32,6 @@ afterAll(async () => {
 describe('Add an existing safe', () => {
   test('Add an existing safe', async (done) => {
     try {
-      done()
       await clickByText('p', 'Add existing Safe', gnosisPage)
       await assertElementPresent(loadSafeForm.form.selector, gnosisPage, 'css')
       await clickAndType(loadSafeForm.safe_name_field, gnosisPage, accountsSelectors.safeNames.load_safe_name)


### PR DESCRIPTION
An additional `done()` is preventing e2e tests to run as expected and they close while still running