### PR TITLE
"refactor wait for executed transaction"

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -47,6 +47,29 @@
 1. Opens modify policies  
 2. Opens selector, selects "1" value  
 3. Signs transaction with current owner, confirm and executes with the 2nd owner  
+4. nonce = ', nonce)
+        // I have to keep asking if the tx with the nonce + 1 is in the history tab, assuring the tx was executed
+        return Array.from(document.querySelectorAll(selector))
+          .map((e) => e.innerText)
+          .includes(nonce.toString())
+      },
+      {},
+      transactionsTab.tx_nonce,
+      firsTransactionNonce,
+    )
+    // Wating for the new tx to show in the history, looking for the nonce
+    let nonce = await getNumberInString(transactionsTab.tx_nonce, gnosisPage, 'css  
+5. nonce = ', nonce)
+        // Once again I repeteadily ask if the latest executed tx nonce is present, should be secondTransactionNonce
+        return Array.from(document.querySelectorAll(selector))
+          .map((e) => e.innerText)
+          .includes(nonce.toString())
+      },
+      {},
+      transactionsTab.tx_nonce,
+      secondTransactionNonce,
+    )
+    nonce = await getNumberInString(transactionsTab.tx_nonce, gnosisPage, 'css  
   
 #### [Reject tx](./../src/reject_tx.test.js)
 1. Checks current ETH funds in safe  

--- a/src/modify_policies.test.js
+++ b/src/modify_policies.test.js
@@ -43,7 +43,7 @@ afterAll(async () => {
 
 describe('Change Policies', () => {
   console.log('Modify policies')
-  let transactionNonce = ''
+  let firsTransactionNonce = ''
 
   test('Change Policies', async () => {
     console.log('Opens modify policies')
@@ -74,7 +74,7 @@ describe('Change Policies', () => {
     // Approving Tx with owner 2
     await gnosisPage.bringToFront()
     await assertTextPresent({ selector: transactionsTab.tx_status, type: 'css' }, 'Needs confirmations', gnosisPage)
-    transactionNonce = await getNumberInString({ selector: 'div.tx-nonce > p', type: 'css' }, gnosisPage)
+    firsTransactionNonce = await getNumberInString('div.tx-nonce > p', gnosisPage, 'css')
     // We approve and execute with account 1
     await approveAndExecuteWithOwner(1, gnosisPage, metamask)
     // Verifying the change in the settings
@@ -84,10 +84,21 @@ describe('Change Policies', () => {
     // waiting for the queue list to be empty and the executed tx to be on the history tab
     await assertElementPresent({ selector: transactionsTab.no_tx_in_queue, type: 'css' }, gnosisPage)
     await clickByText('button > span > p', 'History', gnosisPage)
-    await gnosisPage.waitForTimeout(2000)
+    await gnosisPage.waitForFunction(
+      (selector, nonce) => {
+        console.log('nonce = ', nonce)
+        // I have to keep asking if the tx with the nonce + 1 is in the history tab, assuring the tx was executed
+        return Array.from(document.querySelectorAll(selector))
+          .map((e) => e.innerText)
+          .includes(nonce.toString())
+      },
+      {},
+      transactionsTab.tx_nonce,
+      firsTransactionNonce,
+    )
     // Wating for the new tx to show in the history, looking for the nonce
     let nonce = await getNumberInString({ selector: transactionsTab.tx_nonce, type: 'css' }, gnosisPage)
-    expect(nonce).toBe(transactionNonce)
+    expect(nonce).toBe(firsTransactionNonce)
     await clickElement(transactionsTab.tx_type, gnosisPage)
     const changeConfirmationText = await getInnerText({ selector: 'div.tx-details > p', type: 'css' }, gnosisPage)
     expect(changeConfirmationText).toBe('Change required confirmations:')
@@ -117,10 +128,21 @@ describe('Change Policies', () => {
     await clickByText('button > span > p', 'History', gnosisPage)
     // Wating for the tx execution notification, history should update after
     await isTextPresent('body', 'Transaction successfully executed', gnosisPage)
-    const expectedNonce = transactionNonce + 1
-    await gnosisPage.waitForTimeout(1000)
+    const secondTransactionNonce = firsTransactionNonce + 1
+    await gnosisPage.waitForFunction(
+      (selector, nonce) => {
+        console.log('nonce = ', nonce)
+        // Once again I repeteadily ask if the latest executed tx nonce is present, should be secondTransactionNonce
+        return Array.from(document.querySelectorAll(selector))
+          .map((e) => e.innerText)
+          .includes(nonce.toString())
+      },
+      {},
+      transactionsTab.tx_nonce,
+      secondTransactionNonce,
+    )
     nonce = await getNumberInString({ selector: transactionsTab.tx_nonce, type: 'css' }, gnosisPage)
-    expect(nonce).toBe(expectedNonce)
+    expect(nonce).toBe(secondTransactionNonce)
     await isTextPresent(generalInterface.sidebar, 'SETTINGS', gnosisPage)
     await clickByText(generalInterface.sidebar + ' span', 'settings', gnosisPage)
     await clickByText(generalInterface.sidebar + ' span', 'policies', gnosisPage)

--- a/src/modify_policies.test.js
+++ b/src/modify_policies.test.js
@@ -84,20 +84,15 @@ describe('Change Policies', () => {
     // waiting for the queue list to be empty and the executed tx to be on the history tab
     await assertElementPresent({ selector: transactionsTab.no_tx_in_queue, type: 'css' }, gnosisPage)
     await clickByText('button > span > p', 'History', gnosisPage)
+    // Wating for the new tx to show in the history, looking for the nonce
     await gnosisPage.waitForFunction(
-      (selector, nonce) => {
-        // I have to keep asking if the tx with the nonce + 1 is in the history tab, assuring the tx was executed
-        return Array.from(document.querySelectorAll(selector))
-          .map((e) => e.innerText)
-          .includes(nonce.toString())
-      },
-      {},
+      (selector, nonce) =>
+        // I have to keep asking if the tx with the nonce is in the history tab, assuring the tx was executed
+        document.querySelector(selector).innerText.includes(nonce),
+      { timeout: 0 },
       transactionsTab.tx_nonce,
       firsTransactionNonce,
     )
-    // Wating for the new tx to show in the history, looking for the nonce
-    let nonce = await getNumberInString({ selector: transactionsTab.tx_nonce, type: 'css' }, gnosisPage)
-    expect(nonce).toBe(firsTransactionNonce)
     await clickElement(transactionsTab.tx_type, gnosisPage)
     const changeConfirmationText = await getInnerText({ selector: 'div.tx-details > p', type: 'css' }, gnosisPage)
     expect(changeConfirmationText).toBe('Change required confirmations:')
@@ -129,22 +124,15 @@ describe('Change Policies', () => {
     await isTextPresent('body', 'Transaction successfully executed', gnosisPage)
     const secondTransactionNonce = firsTransactionNonce + 1
     await gnosisPage.waitForFunction(
-      (selector, nonce) => {
-        // Once again I repeteadily ask if the latest executed tx nonce is present, should be secondTransactionNonce
-        return Array.from(document.querySelectorAll(selector))
-          .map((e) => e.innerText)
-          .includes(nonce.toString())
-      },
-      {},
+      (selector, nonce) => document.querySelector(selector).innerText.includes(nonce),
+      { timeout: 0 },
       transactionsTab.tx_nonce,
       secondTransactionNonce,
     )
-    nonce = await getNumberInString({ selector: transactionsTab.tx_nonce, type: 'css' }, gnosisPage)
-    expect(nonce).toBe(secondTransactionNonce)
     await isTextPresent(generalInterface.sidebar, 'SETTINGS', gnosisPage)
     await clickByText(generalInterface.sidebar + ' span', 'settings', gnosisPage)
     await clickByText(generalInterface.sidebar + ' span', 'policies', gnosisPage)
     await isTextPresent('body', 'Required confirmations', gnosisPage)
     await isTextPresent('body', '2 out of', gnosisPage)
-  }, 180000)
+  }, 210000)
 })


### PR DESCRIPTION
Modify policies test - Changed the way we wait for the executed tx in the History tab. Now it actually waits for the expected nonce to show up