### PR TITLE
Checksum validation added

### DIFF
--- a/src/add_remove_owner.test.js
+++ b/src/add_remove_owner.test.js
@@ -80,8 +80,8 @@ describe('Adding and removing owners', () => {
     console.log('Input valid owner name and address')
     // validating checksum
     await clickAndType(settingsPage.add_owner_address_input, gnosisPage, newOwnerAddress.toUpperCase())
-    const NewOwnerAddressChecksummed = await getInnerText(settingsPage.add_owner_address_input, gnosisPage)
-    expect(NewOwnerAddressChecksummed).toEqual(newOwnerAddress)
+    const newOwnerAddressChecksummed = await getInnerText(settingsPage.add_owner_address_input, gnosisPage)
+    expect(newOwnerAddressChecksummed).toEqual(newOwnerAddress)
     await clickElement(settingsPage.add_owner_next_btn, gnosisPage)
 
     console.log('Checks them in review step and submits, confirms and executes')

--- a/src/add_remove_owner.test.js
+++ b/src/add_remove_owner.test.js
@@ -78,7 +78,10 @@ describe('Adding and removing owners', () => {
     await clearInput(settingsPage.add_owner_address_input, gnosisPage)
 
     console.log('Input valid owner name and address')
-    await clickAndType(settingsPage.add_owner_address_input, gnosisPage, newOwnerAddress)
+    // validating checksum
+    await clickAndType(settingsPage.add_owner_address_input, gnosisPage, newOwnerAddress.toUpperCase())
+    const NewOwnerAddressChecksummed = await getInnerText(settingsPage.add_owner_address_input, gnosisPage)
+    expect(NewOwnerAddressChecksummed).toEqual(newOwnerAddress)
     await clickElement(settingsPage.add_owner_next_btn, gnosisPage)
 
     console.log('Checks them in review step and submits, confirms and executes')

--- a/src/address_book.test.js
+++ b/src/address_book.test.js
@@ -64,7 +64,14 @@ describe('Address book', () => {
     console.log('Creates an entry with valid name and address. Validates it in the entries list')
     await clickByText('p', 'Create entry', gnosisPage)
     await clickAndType(addressBook.createEntryNameInput, gnosisPage, accountsSelectors.otherAccountNames.owner5_name)
-    await clickAndType(addressBook.createEntryAddressInput, gnosisPage, accountsSelectors.testAccountsHash.acc1)
+    // Validating checksum
+    await clickAndType(
+      addressBook.createEntryAddressInput,
+      gnosisPage,
+      accountsSelectors.testAccountsHash.acc1.toUpperCase(),
+    )
+    const addressUppercaseFixed = await getInnerText(addressBook.createEntryAddressInput, gnosisPage)
+    expect(addressUppercaseFixed).toEqual(accountsSelectors.testAccountsHash.acc1)
     await clickElement(addressBook.createSubmitBtn, gnosisPage)
     await isTextPresent('tbody', accountsSelectors.otherAccountNames.owner5_name, gnosisPage)
     await isTextPresent('tbody', accountsSelectors.testAccountsHash.acc1, gnosisPage)

--- a/src/create_safe.test.js
+++ b/src/create_safe.test.js
@@ -72,11 +72,11 @@ describe('Create New Safe', () => {
       gnosisPage,
       owner2Address.toUpperCase(),
     )
-    const OwnerAddressChecksummed = await getInnerText(
+    const ownerAddressChecksummed = await getInnerText(
       { selector: createSafePage.address_field(1), type: 'css' },
       gnosisPage,
     )
-    expect(OwnerAddressChecksummed).toEqual(owner2Address)
+    expect(ownerAddressChecksummed).toEqual(owner2Address)
     await assertElementPresent({ selector: createSafePage.valid_address(1), type: 'css' }, gnosisPage)
     rowsAmount = await gnosisPage.$$eval(createSafePage.owner_row, (x) => x.length) // see how many owner I've created
     await assertElementPresent({ selector: createSafePage.req_conf_limit(rowsAmount), type: 'css' }, gnosisPage) // that amount should be in the text "out of X owners"

--- a/src/create_safe.test.js
+++ b/src/create_safe.test.js
@@ -5,6 +5,7 @@ import {
   clickAndType,
   assertTextPresent,
   isTextPresent,
+  getInnerText,
 } from '../utils/selectorsHelpers'
 import { accountsSelectors } from '../utils/selectors/accounts'
 import { createSafePage } from '../utils/selectors/createSafePage'
@@ -65,7 +66,17 @@ describe('Create New Safe', () => {
     await assertElementPresent({ selector: errorMsg.error(errorMsg.required), type: 'Xpath' }, gnosisPage) // check first "required" error in name field
     await clickAndType({ selector: createSafePage.owner_name_field(1), type: 'css' }, gnosisPage, owner2Name) // filling name field
     await assertElementPresent({ selector: errorMsg.error(errorMsg.required), type: 'Xpath' }, gnosisPage) // checking "required" error in address field
-    await clickAndType({ selector: createSafePage.address_field(1), type: 'css' }, gnosisPage, owner2Address)
+    // validate checksum
+    await clickAndType(
+      { selector: createSafePage.address_field(1), type: 'css' },
+      gnosisPage,
+      owner2Address.toUpperCase(),
+    )
+    const OwnerAddressChecksummed = await getInnerText(
+      { selector: createSafePage.address_field(1), type: 'css' },
+      gnosisPage,
+    )
+    expect(OwnerAddressChecksummed).toEqual(owner2Address)
     await assertElementPresent({ selector: createSafePage.valid_address(1), type: 'css' }, gnosisPage)
     rowsAmount = await gnosisPage.$$eval(createSafePage.owner_row, (x) => x.length) // see how many owner I've created
     await assertElementPresent({ selector: createSafePage.req_conf_limit(rowsAmount), type: 'css' }, gnosisPage) // that amount should be in the text "out of X owners"

--- a/src/load_safe.test.js
+++ b/src/load_safe.test.js
@@ -5,6 +5,7 @@ import {
   clickAndType,
   clickByText,
   clickElement,
+  getInnerText,
   isTextPresent,
 } from '../utils/selectorsHelpers'
 import { accountsSelectors } from '../utils/selectors/accounts'
@@ -50,7 +51,10 @@ describe('Add an existing safe', () => {
     console.log('Types name and address for the safe')
     await clickAndType(loadSafeForm.safe_name_field, gnosisPage, accountsSelectors.safeNames.load_safe_name)
     await assertTextPresent(loadSafeForm.valid_safe_name, 'Safe name', gnosisPage)
-    await clickAndType(loadSafeForm.safe_address_field, gnosisPage, TESTING_SAFE_ADDRESS)
+    // validating checksum
+    await clickAndType(loadSafeForm.safe_address_field, gnosisPage, TESTING_SAFE_ADDRESS.toUpperCase())
+    const safeAddressChecksummed = await getInnerText(loadSafeForm.safe_address_field, gnosisPage)
+    expect(safeAddressChecksummed).toEqual(TESTING_SAFE_ADDRESS)
     await assertElementPresent(loadSafeForm.valid_address, gnosisPage)
     await clickElement(generalInterface.submit_btn, gnosisPage)
     // Add Safe owner step edition

--- a/src/replace_owners.test.js
+++ b/src/replace_owners.test.js
@@ -70,7 +70,10 @@ describe('Owner Replacement', () => {
     )
     await clickElement(settingsPage.add_owner_btn, gnosisPage)
     await clickAndType(settingsPage.add_owner_name_input, gnosisPage, newOwnerName)
-    await clickAndType(settingsPage.add_owner_address_input, gnosisPage, newOwnerAddress)
+    // Validating checksum
+    await clickAndType(settingsPage.add_owner_address_input, gnosisPage, newOwnerAddress.toUpperCase())
+    const NewOwnerAddressChecksummed = await getInnerText(settingsPage.add_owner_address_input, gnosisPage)
+    expect(NewOwnerAddressChecksummed).toEqual(newOwnerAddress)
     await clickElement(settingsPage.add_owner_next_btn, gnosisPage)
     await clickElement(settingsPage.add_owner_review_btn, gnosisPage)
     const addedName = await getInnerText(settingsPage.add_owner_name_review, gnosisPage)
@@ -126,7 +129,10 @@ describe('Owner Replacement', () => {
     console.log('Add valid name and address for replacement owner')
     // We get the list of owners, find the one we have to replace and take the index, then click the replace button with the same index
     await clickAndType(settingsPage.replace_owner_name_input, gnosisPage, ownerForReplacementName)
-    await clickAndType(settingsPage.replace_owner_address_input, gnosisPage, ownerForReplacementAddress)
+    // Validating Checksum
+    await clickAndType(settingsPage.replace_owner_address_input, gnosisPage, ownerForReplacementAddress.toUpperCase())
+    const ReplaceOwnerAddressChecksummed = await getInnerText(settingsPage.replace_owner_address_input, gnosisPage)
+    expect(ReplaceOwnerAddressChecksummed).toEqual(ownerForReplacementAddress)
     await clickElement(settingsPage.replace_owner_next_btn, gnosisPage)
     const toReplaceName = await getInnerText(settingsPage.add_owner_name_review, gnosisPage)
     const toReplaceAddress = await getInnerText(settingsPage.add_owner_address_review, gnosisPage)

--- a/src/replace_owners.test.js
+++ b/src/replace_owners.test.js
@@ -72,8 +72,8 @@ describe('Owner Replacement', () => {
     await clickAndType(settingsPage.add_owner_name_input, gnosisPage, newOwnerName)
     // Validating checksum
     await clickAndType(settingsPage.add_owner_address_input, gnosisPage, newOwnerAddress.toUpperCase())
-    const NewOwnerAddressChecksummed = await getInnerText(settingsPage.add_owner_address_input, gnosisPage)
-    expect(NewOwnerAddressChecksummed).toEqual(newOwnerAddress)
+    const newOwnerAddressChecksummed = await getInnerText(settingsPage.add_owner_address_input, gnosisPage)
+    expect(newOwnerAddressChecksummed).toEqual(newOwnerAddress)
     await clickElement(settingsPage.add_owner_next_btn, gnosisPage)
     await clickElement(settingsPage.add_owner_review_btn, gnosisPage)
     const addedName = await getInnerText(settingsPage.add_owner_name_review, gnosisPage)
@@ -131,8 +131,8 @@ describe('Owner Replacement', () => {
     await clickAndType(settingsPage.replace_owner_name_input, gnosisPage, ownerForReplacementName)
     // Validating Checksum
     await clickAndType(settingsPage.replace_owner_address_input, gnosisPage, ownerForReplacementAddress.toUpperCase())
-    const ReplaceOwnerAddressChecksummed = await getInnerText(settingsPage.replace_owner_address_input, gnosisPage)
-    expect(ReplaceOwnerAddressChecksummed).toEqual(ownerForReplacementAddress)
+    const replaceOwnerAddressChecksummed = await getInnerText(settingsPage.replace_owner_address_input, gnosisPage)
+    expect(replaceOwnerAddressChecksummed).toEqual(ownerForReplacementAddress)
     await clickElement(settingsPage.replace_owner_next_btn, gnosisPage)
     const toReplaceName = await getInnerText(settingsPage.add_owner_name_review, gnosisPage)
     const toReplaceAddress = await getInnerText(settingsPage.add_owner_address_review, gnosisPage)

--- a/src/send_funds.test.js
+++ b/src/send_funds.test.js
@@ -68,7 +68,11 @@ describe('Send funds and sign with two owners', () => {
     await assertElementPresent(sendFundsForm.review_btn_disabled, gnosisPage)
     await gnosisPage.waitForTimeout(3000)
     // Fill the form and check error messages when inputs are wrong
-    await clickAndType(sendFundsForm.recipient_input, gnosisPage, FUNDS_RECEIVER_ADDRESS)
+
+    // Input the receiver. Checks checksum validation
+    await clickAndType(sendFundsForm.recipient_input, gnosisPage, FUNDS_RECEIVER_ADDRESS.toUpperCase())
+    const receiverAddressChecksummed = await getInnerText(sendFundsForm.recipient_input_value_entered, gnosisPage)
+    expect(receiverAddressChecksummed).toEqual(FUNDS_RECEIVER_ADDRESS) // The input should checksum the uppercase text automatically.
 
     console.log(
       'Selects ETH token to send (is hardcoded to send only ETH, so it will fail for other networks currently)',
@@ -77,6 +81,8 @@ describe('Send funds and sign with two owners', () => {
     await clickElement(sendFundsForm.select_token_ether, gnosisPage)
 
     await gnosisPage.waitForTimeout(1000)
+    // Validates error fixed in #2758. Remove the comment when 2758 is merged. The Review button should be still be disabled by this point
+    // await assertElementPresent(sendFundsForm.review_btn_disabled, gnosisPage)
 
     console.log('Validates error for invalid amounts: 0, "abc", 99999')
     // Checking that 0 amount triggers an error
@@ -103,7 +109,6 @@ describe('Send funds and sign with two owners', () => {
     const maxInputValue = await getNumberInString(sendFundsForm.amount_input, gnosisPage)
     expect(parseFloat(maxInputValue)).toBe(currentEthFunds)
     await clearInput(sendFundsForm.amount_input, gnosisPage)
-
     await clickAndType(sendFundsForm.amount_input, gnosisPage, TOKEN_AMOUNT.toString())
     await assertElementPresent(sendFundsForm.valid_amount_msg, gnosisPage)
     await clickElement(sendFundsForm.review_btn, gnosisPage)

--- a/utils/selectors/sendFundsForm.js
+++ b/utils/selectors/sendFundsForm.js
@@ -2,6 +2,7 @@ export const sendFundsForm = {
   modal_title_send_funds: { selector: "div[data-testid='modal-title-send-funds']", type: 'css' },
   current_eth_balance: { selector: "b[data-testid='current-eth-balance']", type: 'css' },
   recipient_input: { selector: "input[id='address-book-input']", type: 'css' },
+  recipient_input_value_entered: {selector: ".smaller-modal-window div div div div div p", type: 'css'}, //needs data-testid
   select_token: { selector: "div[id='mui-component-select-token']", type: 'css' },
   review_btn_disabled: { selector: "button[data-testid='review-tx-btn']:disabled", type: 'css' }, // send funds review button initially disabled
   review_btn: { selector: "button[data-testid='review-tx-btn']", type: 'css' },

--- a/utils/selectors/sendFundsForm.js
+++ b/utils/selectors/sendFundsForm.js
@@ -2,7 +2,7 @@ export const sendFundsForm = {
   modal_title_send_funds: { selector: "div[data-testid='modal-title-send-funds']", type: 'css' },
   current_eth_balance: { selector: "b[data-testid='current-eth-balance']", type: 'css' },
   recipient_input: { selector: "input[id='address-book-input']", type: 'css' },
-  recipient_input_value_entered: {selector: ".smaller-modal-window div div div div div p", type: 'css'}, //needs data-testid
+  recipient_input_value_entered: {selector: ".smaller-modal-window div div div div div p", type: 'css'}, // needs data-testid
   select_token: { selector: "div[id='mui-component-select-token']", type: 'css' },
   review_btn_disabled: { selector: "button[data-testid='review-tx-btn']:disabled", type: 'css' }, // send funds review button initially disabled
   review_btn: { selector: "button[data-testid='review-tx-btn']", type: 'css' },


### PR DESCRIPTION
When adding an address I add it with the toUpperCase() method, the value should be automatically checksummed so I compare the value in the input with the checksummed address.

Unrelated to this PR, I Added also in send_funds test a line that will check if the review button is disabled in a specific point during the filling of the send funds form. Is still commented because the fix has not been merged into develop. It should be uncommented once that fix is implemented into the gnosis safe app.