### PR TITLE
Adding verification to tx execution success

### DIFF
--- a/src/modify_policies.test.js
+++ b/src/modify_policies.test.js
@@ -1,4 +1,6 @@
 import { approveAndExecuteWithOwner } from '../utils/actions/approveAndExecuteWithOwner'
+import { verifySuccessfulExecution } from '../utils/actions/verifySuccesfulExecution'
+
 import {
   assertElementPresent,
   assertTextPresent,
@@ -83,16 +85,7 @@ describe('Change Policies', () => {
     await assertTextPresent({ selector: transactionsTab.tx_status, type: 'css' }, 'Pending', gnosisPage)
     // waiting for the queue list to be empty and the executed tx to be on the history tab
     await assertElementPresent({ selector: transactionsTab.no_tx_in_queue, type: 'css' }, gnosisPage)
-    await clickByText('button > span > p', 'History', gnosisPage)
-    // Wating for the new tx to show in the history, looking for the nonce
-    await gnosisPage.waitForFunction(
-      (selector, nonce) =>
-        // I have to keep asking if the tx with the nonce is in the history tab, assuring the tx was executed
-        document.querySelector(selector).innerText.includes(nonce),
-      { timeout: 0 },
-      transactionsTab.tx_nonce,
-      firsTransactionNonce,
-    )
+    await verifySuccessfulExecution(gnosisPage, firsTransactionNonce)
     await clickElement(transactionsTab.tx_type, gnosisPage)
     const changeConfirmationText = await getInnerText({ selector: 'div.tx-details > p', type: 'css' }, gnosisPage)
     expect(changeConfirmationText).toBe('Change required confirmations:')
@@ -119,16 +112,10 @@ describe('Change Policies', () => {
     // Verifying the rollback
     await gnosisPage.bringToFront()
     await gnosisPage.waitForTimeout(2000)
-    await clickByText('button > span > p', 'History', gnosisPage)
     // Wating for the tx execution notification, history should update after
     await isTextPresent('body', 'Transaction successfully executed', gnosisPage)
     const secondTransactionNonce = firsTransactionNonce + 1
-    await gnosisPage.waitForFunction(
-      (selector, nonce) => document.querySelector(selector).innerText.includes(nonce),
-      { timeout: 0 },
-      transactionsTab.tx_nonce,
-      secondTransactionNonce,
-    )
+    await verifySuccessfulExecution(gnosisPage, secondTransactionNonce)
     await isTextPresent(generalInterface.sidebar, 'SETTINGS', gnosisPage)
     await clickByText(generalInterface.sidebar + ' span', 'settings', gnosisPage)
     await clickByText(generalInterface.sidebar + ' span', 'policies', gnosisPage)

--- a/src/send_funds.test.js
+++ b/src/send_funds.test.js
@@ -1,4 +1,5 @@
 import { approveAndExecuteWithOwner } from '../utils/actions/approveAndExecuteWithOwner'
+import { verifySuccessfulExecution } from '../utils/actions/verifySuccesfulExecution'
 import {
   assertElementPresent,
   assertTextPresent,
@@ -52,7 +53,6 @@ afterAll(async () => {
 describe('Send funds and sign with two owners', () => {
   let currentEthFunds = ''
   let currentEthFundsOnText = ''
-  let currentNonce = ''
 
   test('Send funds and return the funds', async () => {
     console.log('Send funds')
@@ -128,7 +128,7 @@ describe('Send funds and sign with two owners', () => {
     // Approving and executing the transaction with owner 2
     await gnosisPage.bringToFront()
     await assertTextPresent({ selector: transactionsTab.tx_status, type: 'css' }, 'Needs confirmations', gnosisPage)
-    currentNonce = await getNumberInString({ selector: 'div.tx-nonce > p', type: 'css' }, gnosisPage)
+    const sendFundsTxNonce = await getNumberInString({ selector: 'div.tx-nonce > p', type: 'css' }, gnosisPage)
     // We approve and execute with account 1
     await approveAndExecuteWithOwner(1, gnosisPage, metamask)
     // Check that transaction was successfully executed
@@ -138,11 +138,8 @@ describe('Send funds and sign with two owners', () => {
     // waiting for the queue list to be empty and the executed tx to be on the history tab
     await assertElementPresent({ selector: transactionsTab.no_tx_in_queue, type: 'css' }, gnosisPage)
     console.log('Goes to history tx tab, checks tx amount sent and receiver address')
-    await clickByText('button > span > p', 'History', gnosisPage)
     // Wating for the new tx to show in the history, looking for the nonce
-    await gnosisPage.waitForTimeout(2000)
-    const nonce = await getNumberInString({ selector: transactionsTab.tx_nonce, type: 'css' }, gnosisPage)
-    expect(nonce).toBe(currentNonce)
+    await verifySuccessfulExecution(gnosisPage, sendFundsTxNonce)
     const sentAmount = await getInnerText({ selector: transactionsTab.tx_info, type: 'css' }, gnosisPage)
     expect(sentAmount).toBe(`-${TOKEN_AMOUNT.toString()} ETH`)
     await clickElement(transactionsTab.tx_type, gnosisPage)

--- a/utils/actions/verifySuccesfulExecution.js
+++ b/utils/actions/verifySuccesfulExecution.js
@@ -1,0 +1,31 @@
+import {
+    clickByText,
+    getInnerText,
+    getNumberInString,
+  } from '../selectorsHelpers'
+import { transactionsTab } from '../selectors/transactionsTab'
+
+/**
+ * This tx verifies the successful execution of a signed tx. After the submit of the tx by the first owner, in the queue tab
+ * you must get the nonce number of the new tx with:
+ * const nonce = await getNumberInString({ selector: 'div.tx-nonce > p', type: 'css' }, gnosisPage)
+ * After the execution of the tx call this function with that nonce
+ * 
+ * @param {number} nonce is the nonce of the current tx 
+ * @param {gnosisPage} gnosisPage puppeteer instance of Gnosis Safe page
+ *
+ */
+
+export const verifySuccessfulExecution = async (gnosisPage, nonce) => {
+await clickByText('button > span > p', 'History', gnosisPage)
+await gnosisPage.waitForFunction(
+    (selector, nonce) => document.querySelector(selector).innerText.includes(nonce),
+    { timeout: 0 },
+    transactionsTab.tx_nonce,
+    nonce,
+  )
+  const currentNonce = await getNumberInString({ selector: transactionsTab.tx_nonce, type: 'css' }, gnosisPage)
+  expect(currentNonce).toBe(nonce)
+  const executedTxStatus = await getInnerText({ selector: transactionsTab.tx_status, type: 'css' }, gnosisPage)
+  expect(executedTxStatus).toBe('Success')
+}

--- a/utils/selectorsHelpers.js
+++ b/utils/selectorsHelpers.js
@@ -42,7 +42,7 @@ export const clearInput = async function ({ selector, type = 'Xpath' }, page) {
 }
 
 export const assertElementPresent = async function ({ selector, type = 'Xpath' }, page) {
-  const element = await elementSelector(selector, page, type, 90000)
+  const element = await elementSelector(selector, page, type, 120000)
   const expectHandler = expect(element)
   type !== 'Xpath' ? expectHandler.not.toBeNull() : expectHandler.toBeDefined() // for Css there is a different condition to make
   return element


### PR DESCRIPTION
* Validation after every tx execution made a function we can use anywhere. It was already being done, so this is removing duplicated code
* Change some "nouce" variables to be more specific
* Add more "time limit" to tests because of several timeouts during testing