### PR TITLE
Safe Apps List tests

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -115,17 +115,20 @@
 3. Opens a Safe App
 4. Shows Disclaimer and clicks on accept
 5. Loads Safe Apps in an iframe
-6. Bookmarks Safe Apps
-7. Searches by Safe App Title and Description
-8. Shows the add custom Safe Apps form
-9. Populates the custom the Safe App url and name
-10. "Add Custom Safe App" button should be disabled if the checkbox is unchecked
-11. Adds a custom Safe Apps
-12. Loads the Custom App in an iframe
-13. Shows the Custom Safe App in the Apps List
-14. Validates the custom Safe App Url
-15. Validates if the Custom Safe App was already added
-16. Removes a Custom Safe App
+6. Pins Safe Apps
+7. Refresh the page should keep the Bookmarked Safe Apps
+8. Unpins Safe Apps
+9. Searches by Safe App Title
+10. Searches by Safe App Description
+11. Shows the add custom Safe Apps form
+12. Populates the custom the Safe App url and name
+13. "Add Custom Safe App" button should be disabled if the checkbox is unchecked
+14. Adds a custom Safe Apps
+15. Loads the Custom App in an iframe
+16. Shows the Custom Safe App in the Apps List
+17. Validates the custom Safe App Url
+18. Validates if the Custom Safe App was already added
+19. Removes a Custom Safe App
 
 #### [Send funds](./../src/send_funds.test.js)
 1. Open the send funds form

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -109,6 +109,24 @@
 5. Signs and executes
 6. Checks status success of executed tx
 
+#### [Safe Apps List](./../src/safe_apps_list.test.js)
+1. Shows Bookmarked Apps Section
+2. Shows All Apps Section
+3. Opens a Safe App
+4. Shows Disclaimer and clicks on accept
+5. Loads Safe Apps in an iframe
+6. Bookmarks Safe Apps
+7. Searches by Safe App Title and Description
+8. Shows the add custom Safe Apps form
+9. Populates the custom the Safe App url and name
+10. "Add Custom Safe App" button should be disabled if the checkbox is unchecked
+11. Adds a custom Safe Apps
+12. Loads the Custom App in an iframe
+13. Shows the Custom Safe App in the Apps List
+14. Validates the custom Safe App Url
+15. Validates if the Custom Safe App was already added
+16. Removes a Custom Safe App
+
 #### [Send funds](./../src/send_funds.test.js)
 1. Open the send funds form
 2. Types a receiver address

--- a/src/safe_apps_list.test.js
+++ b/src/safe_apps_list.test.js
@@ -41,8 +41,9 @@ afterAll(async () => {
 describe('Safe Apps List', () => {
   test('Safe Apps List', async () => {
     console.log('Safe Apps List')
+    const safeAppsListUrl = `${getEnvUrl()}#/safes/${TESTING_SAFE_ADDRESS}/apps`
 
-    await gnosisPage.goto(`${getEnvUrl()}#/safes/${TESTING_SAFE_ADDRESS}/apps`)
+    await gnosisPage.goto(safeAppsListUrl)
 
     console.log('Shows Bookmarked Apps Section')
     await assertTextPresent(safeAppsList.bookmarkedSafeAppsSection, 'BOOKMARKED APPS', gnosisPage)
@@ -51,7 +52,7 @@ describe('Safe Apps List', () => {
     await assertElementPresent(safeAppsList.allSafeAppsSection, gnosisPage)
 
     console.log('Opens a Safe App')
-    await clickElement(safeAppsList.walletConnectSafeAppLogo, gnosisPage)
+    await clickElement(safeAppsList.getSafeAppByTitle('WalletConnect'), gnosisPage)
 
     console.log('Shows Disclaimer and clicks on accept')
     await assertElementPresent(safeAppsList.disclaimerTitleSafeAppPopUp, gnosisPage)
@@ -61,19 +62,43 @@ describe('Safe Apps List', () => {
     console.log('Loads Safe Apps in an iframe')
     await assertElementPresent(safeAppsList.getSafeAppIframeByTitle('WalletConnect'), gnosisPage)
 
-    await gnosisPage.goto(`${getEnvUrl()}#/safes/${TESTING_SAFE_ADDRESS}/apps`)
+    await gnosisPage.goto(safeAppsListUrl)
 
-    console.log('Bookmarks Safe Apps')
+    console.log('Pins Safe Apps')
     // WalletConnect Safe App is not bookmarked
     await assertElementNotPresent(safeAppsList.getBookmarkedSafeApp('WalletConnect'), gnosisPage)
     // we add WalletConnect Safe App to bookmarked section
     await clickElement(safeAppsList.getPinSafeAppButton('WalletConnect'), gnosisPage)
     await assertElementPresent(safeAppsList.getBookmarkedSafeApp('WalletConnect'), gnosisPage)
 
-    // TODO: Search feature
-    console.log('Searches by Safe App Title and Description')
+    console.log('Refresh the page should keep the Bookmarked Safe Apps')
+    await gnosisPage.goto(safeAppsListUrl)
+    await assertElementPresent(safeAppsList.getBookmarkedSafeApp('WalletConnect'), gnosisPage)
+
+    console.log('Unpins Safe Apps')
+    await clickElement(safeAppsList.getUnpinSafeAppButton('WalletConnect'), gnosisPage)
+    await assertElementNotPresent(safeAppsList.getBookmarkedSafeApp('WalletConnect'), gnosisPage)
+
+    console.log('Searches by Safe App Title')
     await assertElementPresent(safeAppsList.searchInput, gnosisPage)
-    // Search by Safe Apps title and description
+    await assertElementPresent(safeAppsList.getSafeAppByTitle('WalletConnect'), gnosisPage)
+    await assertElementPresent(safeAppsList.getSafeAppByTitle('Compound'), gnosisPage)
+    const searchByAppTitle = 'walletCon'
+    await clickAndType(safeAppsList.searchInput, gnosisPage, searchByAppTitle)
+    await assertElementPresent(safeAppsList.getSafeAppByTitle('WalletConnect'), gnosisPage)
+    await assertElementNotPresent(safeAppsList.getSafeAppByTitle('Compound'), gnosisPage)
+
+    console.log('Searches by Safe App Description')
+    await clearInput(safeAppsList.searchInput, gnosisPage)
+    await assertElementPresent(safeAppsList.getSafeAppByTitle('WalletConnect'), gnosisPage)
+    await assertElementPresent(safeAppsList.getSafeAppByTitle('Compound'), gnosisPage)
+    const searchByAppDescription = 'Allows your Gnosis Safe Multisig'
+    await clickAndType(safeAppsList.searchInput, gnosisPage, searchByAppDescription)
+    await assertElementPresent(safeAppsList.getSafeAppByTitle('WalletConnect'), gnosisPage)
+    await assertElementNotPresent(safeAppsList.getSafeAppByTitle('Compound'), gnosisPage)
+
+    // clear input to show all sections again
+    await clearInput(safeAppsList.searchInput, gnosisPage)
 
     console.log('Shows the add custom Safe Apps form')
     await clickByText(safeAppsList.addCustomSafeAppButton.selector, 'Add custom app', gnosisPage)

--- a/src/safe_apps_list.test.js
+++ b/src/safe_apps_list.test.js
@@ -1,0 +1,125 @@
+import {
+  assertElementNotPresent,
+  assertElementPresent,
+  assertTextPresent,
+  clearInput,
+  clickAndType,
+  clickByText,
+  clickElement,
+  getInnerText,
+} from '../utils/selectorsHelpers'
+import { rejectPendingTxs } from '../utils/actions/rejectPendingTxs'
+import { getEnvUrl, initWithWalletConnected } from '../utils/testSetup'
+import config from '../utils/config'
+import { safeAppsList } from '../utils/selectors/safeAppsList'
+
+/*
+Safe Apps List
+-- Shows the Safe Apps List
+-- Opens a Safe Apps
+-- Search by Safe Apps title and description
+-- Adds a Bookmarked Safe Apps
+-- Adds a Custom Safe Apps
+*/
+
+let browser
+let metamask
+let gnosisPage
+
+const { TESTING_SAFE_ADDRESS } = config
+
+beforeAll(async () => {
+  ;[browser, metamask, gnosisPage] = await initWithWalletConnected()
+}, 60000)
+
+afterAll(async () => {
+  await rejectPendingTxs(gnosisPage, metamask)
+  await gnosisPage.waitForTimeout(2000)
+  await browser.close()
+})
+
+describe('Safe Apps List', () => {
+  test('Safe Apps List', async () => {
+    console.log('Safe Apps List')
+
+    await gnosisPage.goto(`${getEnvUrl()}#/safes/${TESTING_SAFE_ADDRESS}/apps`)
+
+    console.log('Shows Bookmarked Apps Section')
+    await assertTextPresent(safeAppsList.bookmarkedSafeAppsSection, 'BOOKMARKED APPS', gnosisPage)
+
+    console.log('Shows All Apps Section')
+    await assertElementPresent(safeAppsList.allSafeAppsSection, gnosisPage)
+
+    console.log('Opens a Safe App')
+    await clickElement(safeAppsList.walletConnectSafeAppLogo, gnosisPage)
+
+    console.log('Shows Disclaimer and clicks on accept')
+    await assertElementPresent(safeAppsList.disclaimerTitleSafeAppPopUp, gnosisPage)
+    expect(await getInnerText(safeAppsList.disclaimerTitleSafeAppPopUp, gnosisPage)).toBe('Disclaimer')
+    await clickElement(safeAppsList.acceptDisclaimerButton, gnosisPage)
+
+    console.log('Loads Safe Apps in an iframe')
+    await assertElementPresent(safeAppsList.getSafeAppIframeByTitle('WalletConnect'), gnosisPage)
+
+    await gnosisPage.goto(`${getEnvUrl()}#/safes/${TESTING_SAFE_ADDRESS}/apps`)
+
+    console.log('Bookmarks Safe Apps')
+    // WalletConnect Safe App is not bookmarked
+    await assertElementNotPresent(safeAppsList.getBookmarkedSafeApp('WalletConnect'), gnosisPage)
+    // we add WalletConnect Safe App to bookmarked section
+    await clickElement(safeAppsList.getPinSafeAppButton('WalletConnect'), gnosisPage)
+    await assertElementPresent(safeAppsList.getBookmarkedSafeApp('WalletConnect'), gnosisPage)
+
+    // TODO: Search feature
+    console.log('Searches by Safe App Title and Description')
+    await assertElementPresent(safeAppsList.searchInput, gnosisPage)
+    // Search by Safe Apps title and description
+
+    console.log('Shows the add custom Safe Apps form')
+    await clickByText(safeAppsList.addCustomSafeAppButton.selector, 'Add custom app', gnosisPage)
+    await assertElementPresent(safeAppsList.addCustomAppForm, gnosisPage)
+
+    console.log('Populates the custom the Safe App url and name')
+    const customAppUrl = 'https://ipfs.io/ipfs/QmfMq8NgxdDfai1qKv7bGbT8DegYX4mNzmpi9AkY1VJZBS/'
+    const customAppName = 'Safe Test App'
+    await clickAndType(safeAppsList.addCustomAppUrlInput, gnosisPage, customAppUrl)
+    await gnosisPage.waitForTimeout(5000) // this can be improved
+    expect(await getInnerText(safeAppsList.addCustomAppNameInput, gnosisPage)).toBe(customAppName)
+
+    console.log('"Add Custom Safe App" button should be disabled if the checkbox is unchecked')
+    const addCustomAppFromButton = await gnosisPage.waitForSelector(safeAppsList.addCustomAppFromButton.selector)
+    expect(await addCustomAppFromButton.evaluate((node) => node.disabled)).toBe(true)
+    await clickElement(safeAppsList.addCustomAppCheckbox, gnosisPage)
+    expect(await addCustomAppFromButton.evaluate((node) => node.disabled)).toBe(false)
+
+    console.log('Adds a custom Safe Apps')
+    await clickElement(safeAppsList.addCustomAppFromButton, gnosisPage)
+
+    console.log('Loads the Custom App in an iframe')
+    await assertElementPresent(safeAppsList.getSafeAppIframeByUrl(customAppUrl), gnosisPage)
+
+    console.log('Shows the Custom Safe App in the Apps List')
+    await gnosisPage.goto(`${getEnvUrl()}#/safes/${TESTING_SAFE_ADDRESS}/apps`)
+    await assertElementPresent(safeAppsList.customSafeAppLogo, gnosisPage)
+
+    console.log('Validates the custom Safe App Url')
+    await clickByText(safeAppsList.addCustomSafeAppButton.selector, 'Add custom app', gnosisPage)
+    const invalidSafeAppUrl = 'this is an invalid safe app url'
+    await clickAndType(safeAppsList.addCustomAppUrlInput, gnosisPage, invalidSafeAppUrl)
+    await assertTextPresent(safeAppsList.addCustomAppUrlErrorLabel, 'Invalid URL', gnosisPage)
+
+    console.log('Validates if the Custom Safe App was already added')
+    const alreadyAddedSafeAppError = 'This app is already registered.'
+    await clearInput(safeAppsList.addCustomAppUrlInput, gnosisPage)
+    await clickAndType(safeAppsList.addCustomAppUrlInput, gnosisPage, customAppUrl)
+    await assertTextPresent(safeAppsList.addCustomAppUrlErrorLabel, alreadyAddedSafeAppError, gnosisPage)
+    await clickElement(safeAppsList.closePopupIcon, gnosisPage)
+
+    console.log('Removes a Custom Safe App')
+    await clickElement(safeAppsList.removeCustomSafeAppButton, gnosisPage)
+    // shows the confirmation popup
+    await assertElementPresent(safeAppsList.removeCustomSafeAppPopup, gnosisPage)
+    await clickElement(safeAppsList.confirmRemoveCustomSafeAppButton, gnosisPage)
+    await assertElementNotPresent(safeAppsList.customSafeAppLogo, gnosisPage)
+  }, 480000)
+})

--- a/src/safe_apps_list.test.js
+++ b/src/safe_apps_list.test.js
@@ -26,7 +26,7 @@ let browser
 let metamask
 let gnosisPage
 
-const { TESTING_SAFE_ADDRESS } = config
+const { TESTING_SAFE_ADDRESS, NETWORK_ADDRESS_PREFIX } = config
 
 beforeAll(async () => {
   ;[browser, metamask, gnosisPage] = await initWithWalletConnected()
@@ -41,7 +41,7 @@ afterAll(async () => {
 describe('Safe Apps List', () => {
   test('Safe Apps List', async () => {
     console.log('Safe Apps List')
-    const safeAppsListUrl = `${getEnvUrl()}#/safes/${TESTING_SAFE_ADDRESS}/apps`
+    const safeAppsListUrl = `${getEnvUrl()}app/${NETWORK_ADDRESS_PREFIX}:${TESTING_SAFE_ADDRESS}/apps`
 
     await gnosisPage.goto(safeAppsListUrl)
 
@@ -124,7 +124,7 @@ describe('Safe Apps List', () => {
     await assertElementPresent(safeAppsList.getSafeAppIframeByUrl(customAppUrl), gnosisPage)
 
     console.log('Shows the Custom Safe App in the Apps List')
-    await gnosisPage.goto(`${getEnvUrl()}#/safes/${TESTING_SAFE_ADDRESS}/apps`)
+    await gnosisPage.goto(safeAppsListUrl)
     await assertElementPresent(safeAppsList.customSafeAppLogo, gnosisPage)
 
     console.log('Validates the custom Safe App Url')

--- a/utils/selectors/safeAppsList.js
+++ b/utils/selectors/safeAppsList.js
@@ -1,0 +1,38 @@
+export const safeAppsList = {
+  bookmarkedSafeAppsSection: { selector: 'div[role="button"]:nth-of-type(1)', type: 'css' },
+  allSafeAppsSection: { selector: 'div[data-testid="safe_apps__all-apps-container"]', type: 'css' },
+
+  walletConnectSafeAppLogo: { selector: 'img[alt="WalletConnect Logo"]', type: 'css' },
+
+  searchInput: { selector: 'input[aria-label="search"]', type: 'css' },
+
+  getSafeAppIframeByUrl: (safeAppUrl) => ({ selector: `iframe[src="${safeAppUrl}"]`, type: 'css' }),
+  getSafeAppIframeByTitle: (safeAppTile) => ({ selector: `iframe[title="${safeAppTile}"]`, type: 'css' }),
+
+  bookmarkedSafeAppsContainer: { selector: 'div[data-testid="safe_apps__pinned-apps-container"]', type: 'css' },
+  getBookmarkedSafeApp: (safeAppTile) => ({
+    selector: `div[data-testid="safe_apps__pinned-apps-container"] img[alt="${safeAppTile} Logo"]`,
+    type: 'css',
+  }),
+  getUnpinSafeAppButton: (safeAppTile) => ({ selector: `button[aria-label="Unpin ${safeAppTile}"]`, type: 'css' }),
+  getPinSafeAppButton: (safeAppTile) => ({ selector: `button[aria-label="Pin ${safeAppTile}"]`, type: 'css' }),
+
+  addCustomSafeAppButton: {
+    selector: 'div[data-testid="safe_apps__all-apps-container"] > div:nth-child(1) button',
+    type: 'css',
+  },
+  addCustomAppForm: { selector: 'form[data-testid="add-apps-form"]', type: 'css' },
+  addCustomAppUrlInput: { selector: 'input[placeholder="App URL"]', type: 'css' },
+  addCustomAppUrlErrorLabel: { selector: 'label.Mui-error', type: 'css' },
+  addCustomAppNameInput: { selector: 'form[data-testid="add-apps-form"] input[disabled]', type: 'css' },
+  addCustomAppFromButton: { selector: 'form[data-testid="add-apps-form"] button[type="submit"]', type: 'css' },
+  addCustomAppCheckbox: { selector: 'form[data-testid="add-apps-form"] input[type="checkbox"]', type: 'css' },
+  closePopupIcon: { selector: 'button.close-button', type: 'css' },
+  customSafeAppLogo: { selector: 'img[alt="Safe Test App Logo"]', type: 'css' },
+  removeCustomSafeAppButton: { selector: 'button[aria-label="Remove an app"]', type: 'css' },
+  removeCustomSafeAppPopup: { selector: 'div[aria-describedby="Confirm for the app removal"]', type: 'css' },
+  confirmRemoveCustomSafeAppButton: { selector: 'div[aria-describedby="Confirm for the app removal"] div.modal-footer button:nth-child(2)', type: 'css' },
+
+  disclaimerTitleSafeAppPopUp: { selector: 'h5', type: 'css' },
+  acceptDisclaimerButton: { selector: 'button[type="button"].contained', type: 'css' },
+}

--- a/utils/selectors/safeAppsList.js
+++ b/utils/selectors/safeAppsList.js
@@ -2,7 +2,10 @@ export const safeAppsList = {
   bookmarkedSafeAppsSection: { selector: 'div[role="button"]:nth-of-type(1)', type: 'css' },
   allSafeAppsSection: { selector: 'div[data-testid="safe_apps__all-apps-container"]', type: 'css' },
 
-  walletConnectSafeAppLogo: { selector: 'img[alt="WalletConnect Logo"]', type: 'css' },
+  getSafeAppByTitle: (safeAppTitle) => ({
+    selector: `div[data-testid="safe_apps__all-apps-container"] img[alt="${safeAppTitle} Logo"]`,
+    type: 'css',
+  }),
 
   searchInput: { selector: 'input[aria-label="search"]', type: 'css' },
 
@@ -31,7 +34,10 @@ export const safeAppsList = {
   customSafeAppLogo: { selector: 'img[alt="Safe Test App Logo"]', type: 'css' },
   removeCustomSafeAppButton: { selector: 'button[aria-label="Remove an app"]', type: 'css' },
   removeCustomSafeAppPopup: { selector: 'div[aria-describedby="Confirm for the app removal"]', type: 'css' },
-  confirmRemoveCustomSafeAppButton: { selector: 'div[aria-describedby="Confirm for the app removal"] div.modal-footer button:nth-child(2)', type: 'css' },
+  confirmRemoveCustomSafeAppButton: {
+    selector: 'div[aria-describedby="Confirm for the app removal"] div.modal-footer button:nth-child(2)',
+    type: 'css',
+  },
 
   disclaimerTitleSafeAppPopUp: { selector: 'h5', type: 'css' },
   acceptDisclaimerButton: { selector: 'button[type="button"].contained', type: 'css' },


### PR DESCRIPTION
Added Safe Apps List tests

this can be tested in the [dev branch](https://github.com/gnosis/safe-react/tree/dev)

#### [Safe Apps List](./../src/safe_apps_list.test.js)
1. Shows Bookmarked Apps Section
2. Shows All Apps Section
3. Opens a Safe App
4. Shows Disclaimer and clicks on accept
5. Loads Safe Apps in an iframe
6. Pins Safe Apps
7. Refresh the page should keep the Bookmarked Safe Apps
8. Unpins Safe Apps
9. Searches by Safe App Title
10. Searches by Safe App Description
11. Shows the add custom Safe Apps form
12. Populates the custom the Safe App url and name
13. "Add Custom Safe App" button should be disabled if the checkbox is unchecked
14. Adds a custom Safe Apps
15. Loads the Custom App in an iframe
16. Shows the Custom Safe App in the Apps List
17. Validates the custom Safe App Url
18. Validates if the Custom Safe App was already added
19. Removes a Custom Safe App
