### PR TITLE
Move test suite to read_only folder

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,12 +1,3 @@
-#### [Create and review a Send Funds transaction](./../src/read_only/review_tx.test.js)
-1. Open the send funds form
-2. Types a receiver address
-3. Validates error for invalid amounts: 0, "abc", 99999
-4. Checks "Send max" button
-5. Checks receiver address in the review step
-6. Checks the amount input
-7. Opens advanced options
-
 #### [Safe Apps liveness](./../src/safe-apps/working_apps.test.js)
 1. Open Safe Apps List
 2. Get all apps
@@ -106,6 +97,15 @@
 14. Loads the safe
 15. Opens the QR code for the safe on the sidebar and checks the safe name again
 
+
+#### [Create and review a Send Funds transaction](./../src/safe-web/read_only/review_tx.test.js)
+1. Open the send funds form
+2. Types a receiver address
+3. Validates error for invalid amounts: 0, "abc", 99999
+4. Checks "Send max" button
+5. Checks receiver address in the review step
+6. Checks the amount input
+7. Opens advanced options
 
 #### [Safe Apps List](./../src/safe-web/read_only/safe_apps_list.test.js)
 1. Shows Bookmarked Apps Section

--- a/src/safe-web/read_only/review_tx.test.js
+++ b/src/safe-web/read_only/review_tx.test.js
@@ -7,13 +7,13 @@ import {
   getNumberInString,
   getInnerText,
   openDropdown,
-} from '../../utils/selectorsHelpers'
-import { assetsTab } from '../../utils/selectors/assetsTab'
-import { generalInterface } from '../../utils/selectors/generalInterface'
-import { sendFundsForm } from '../../utils/selectors/sendFundsForm'
-import { errorMsg } from '../../utils/selectors/errorMsg'
-import { initWithDefaultSafeDirectNavigation } from '../../utils/testSetup'
-import config from '../../utils/config'
+} from '../../../utils/selectorsHelpers'
+import { assetsTab } from '../../../utils/selectors/assetsTab'
+import { generalInterface } from '../../../utils/selectors/generalInterface'
+import { sendFundsForm } from '../../../utils/selectors/sendFundsForm'
+import { errorMsg } from '../../../utils/selectors/errorMsg'
+import { initWithDefaultSafeDirectNavigation } from '../../../utils/testSetup'
+import config from '../../../utils/config'
 
 /*
 Create and review a Send Funds transaction


### PR DESCRIPTION
After merging [a pull request](https://github.com/gnosis/safe-react-e2e-tests/pull/89) resolving some conflicts the `review_tx` suite was left in a wrong folder. This PR move it to the correct one